### PR TITLE
Pinned results doesn't support comma-separated phrases

### DIFF
--- a/src/OptiGraphExtensions/Entities/PinnedResult.cs
+++ b/src/OptiGraphExtensions/Entities/PinnedResult.cs
@@ -11,7 +11,7 @@ namespace OptiGraphExtensions.Entities
 
         public Guid CollectionId { get; set; }
 
-        public string? Phrases { get; set; } // Comma-separated search phrases
+        public string? Phrases { get; set; } // Search phrase
 
         public string? TargetKey { get; set; } // Content GUID to pin
 

--- a/src/OptiGraphExtensions/Features/PinnedResults/PinnedResultsManagementComponent.razor
+++ b/src/OptiGraphExtensions/Features/PinnedResults/PinnedResultsManagementComponent.razor
@@ -172,9 +172,9 @@
             {
                 <div class="epi-form-row">
                     <div class="epi-form-field epi-form-field--half">
-                        <label for="newPhrases" class="epi-label">Search Phrases (comma-separated)</label>
+                        <label for="newPhrases" class="epi-label">Search Phrase</label>
                         <input id="newPhrases" @bind="NewPinnedResult.Phrases"
-                               class="epi-textbox" placeholder="e.g., laptop, computer, notebook" maxlength="1000" />
+                               class="epi-textbox" placeholder="e.g., laptop" maxlength="1000" />
                     </div>
                     <div class="epi-form-field epi-form-field--quarter">
                         <label for="contentTypeFilter" class="epi-label">Content Type Filter</label>


### PR DESCRIPTION
From Optimizely:
_When calling the API to create a pinned item, the parameter should be phrase instead of phrases.
This means you need to call the API twice to create two separate phrases for the same target key._